### PR TITLE
Fix crash on startup when using push notifications for social challenges

### DIFF
--- a/OKPlugins/OpenKit/Native/OpenKitIOS.cs
+++ b/OKPlugins/OpenKit/Native/OpenKitIOS.cs
@@ -76,12 +76,16 @@ namespace OpenKit.Native
 
 		[DllImport (OK_IPHONE_DLL)]
 		public static extern void OKBridgeShowAchievementsLandscapeOnly();
+		
+		[DllImport (OK_IPHONE_DLL)]
+		public static extern void InitRemoteNotifications();
 
 		public OpenKitIOS() {}
 		
 		public void Configure(string appKey, string secretKey, string endpoint) 
 		{
 			OKBridgeConfigureOpenKit(appKey, secretKey, endpoint);
+			InitRemoteNotifications();
 		}
 
 		public void ShowLeaderboards()

--- a/OKPlugins/OpenKit/PostbuildScripts/PostBuildOpenKitIOSScript
+++ b/OKPlugins/OpenKit/PostbuildScripts/PostBuildOpenKitIOSScript
@@ -90,7 +90,6 @@ foreach (@FILES) {
 				if($didFinish == 1){
 					$didFinish = -1;
 					print SOURCEFILE "\t[OKManager sharedManager];\n";
-					print SOURCEFILE "\t[[UIApplication sharedApplication] registerForRemoteNotificationTypes:UIRemoteNotificationTypeAlert | UIRemoteNotificationTypeSound];\n"
 				} elsif ($handle1 == 1) {
 					$handle1 = -1;
 					print SOURCEFILE "\t[OKManager handleOpenURL:url];\n";

--- a/OKPlugins/iOS/OpenKitUtils.mm
+++ b/OKPlugins/iOS/OpenKitUtils.mm
@@ -1,0 +1,7 @@
+#include <UIKit/UIKit.h>
+
+extern "C" void InitRemoteNotifications()
+{
+	[[UIApplication sharedApplication] registerForRemoteNotificationTypes:UIRemoteNotificationTypeAlert | UIRemoteNotificationTypeSound];
+}
+


### PR DESCRIPTION
With push notifications setup for social challenges, Unity apps on iOS will crash on their first run after installation on a device. The cause was that registerForRemoteNotificationTypes was being inserted into the app controller's didFinishLaunching, but Unity has not yet had a chance to run the OKInitializer yet at this early moment!

This pull request fixes the issue by delaying the call to registerForRemoteNotificationTypes until the OKInitializer has had a chance to run from Unity. (Or whatever the dev is using to call Configure on OK).
